### PR TITLE
Add the optional health-port flag used for the health check URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,10 +43,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	colonSeparator = ":"
-	slashSeparator = "/"
-)
+const slashSeparator = "/"
 
 var (
 	globalQuietEnabled   bool
@@ -199,10 +196,13 @@ func registerMetricsRouter(router *mux.Router) error {
 // getHealthCheckURL - extracts the health check URL.
 func getHealthCheckURL(endpoint, healthCheckPath string, healthCheckPort int) string {
 	healthCheckURL, _ := url.Parse(strings.TrimSuffix(endpoint, slashSeparator) + healthCheckPath)
-	if healthCheckPort != 0 {
-		host, _, _ := net.SplitHostPort(healthCheckURL.Host)
-		healthCheckURL.Host = host + colonSeparator + strconv.Itoa(healthCheckPort)
+	if healthCheckPort == 0 {
+		return healthCheckURL.String()
 	}
+
+	// Set health check port
+	host, _, _ := net.SplitHostPort(healthCheckURL.Host)
+	healthCheckURL.Host = net.JoinHostPort(host, strconv.Itoa(healthCheckPort))
 
 	return healthCheckURL.String()
 }

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -42,7 +43,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const slashSeparator = "/"
+const (
+	colonSeparator = ":"
+	slashSeparator = "/"
+)
 
 var (
 	globalQuietEnabled   bool
@@ -128,6 +132,7 @@ type Backend struct {
 	httpClient          *http.Client
 	up                  int32
 	healthCheckPath     string
+	healthCheckPort     int
 	healthCheckDuration int
 	Stats               *BackendStats
 	DowntimeStart       time.Time
@@ -191,9 +196,20 @@ func registerMetricsRouter(router *mux.Router) error {
 	return nil
 }
 
+// getHealthCheckURL - extracts the health check URL.
+func getHealthCheckURL(endpoint, healthCheckPath string, healthCheckPort int) string {
+	healthCheckURL, _ := url.Parse(strings.TrimSuffix(endpoint, slashSeparator) + healthCheckPath)
+	if healthCheckPort != 0 {
+		host, _, _ := net.SplitHostPort(healthCheckURL.Host)
+		healthCheckURL.Host = host + colonSeparator + strconv.Itoa(healthCheckPort)
+	}
+
+	return healthCheckURL.String()
+}
+
 // healthCheck - background routine which checks if a backend is up or down.
 func (b *Backend) healthCheck() {
-	healthCheckURL := strings.TrimSuffix(b.endpoint, slashSeparator) + b.healthCheckPath
+	healthCheckURL := getHealthCheckURL(b.endpoint, b.healthCheckPath, b.healthCheckPort)
 	for {
 		reqTime := time.Now().UTC()
 		req, err := http.NewRequest(http.MethodGet, healthCheckURL, nil)
@@ -485,7 +501,7 @@ func checkMain(ctx *cli.Context) {
 	}
 }
 
-func configureSite(ctx *cli.Context, siteNum int, siteStrs []string, healthCheckPath string, healthCheckDuration int) *site {
+func configureSite(ctx *cli.Context, siteNum int, siteStrs []string, healthCheckPath string, healthCheckPort int, healthCheckDuration int) *site {
 	var endpoints []string
 
 	if ellipses.HasEllipses(siteStrs...) {
@@ -530,7 +546,7 @@ func configureSite(ctx *cli.Context, siteNum int, siteStrs []string, healthCheck
 		stats := BackendStats{MinLatency: time.Duration(24 * time.Hour), MaxLatency: time.Duration(0)}
 		backend := &Backend{siteNum, endpoint, proxy, &http.Client{
 			Transport: proxy.Transport,
-		}, 0, healthCheckPath, healthCheckDuration, &stats, timeZero, newCacheClient(ctx, cacheCfg)}
+		}, 0, healthCheckPath, healthCheckPort, healthCheckDuration, &stats, timeZero, newCacheClient(ctx, cacheCfg)}
 		go backend.healthCheck()
 		proxy.ErrorHandler = backend.ErrorHandler
 		backends = append(backends, backend)
@@ -553,6 +569,7 @@ func sidekickMain(ctx *cli.Context) {
 	log.SetReportCaller(true)
 
 	healthCheckPath := ctx.GlobalString("health-path")
+	healthCheckPort := ctx.GlobalInt("health-port")
 	healthCheckDuration := ctx.GlobalInt("health-duration")
 	addr := ctx.GlobalString("address")
 	globalLoggingEnabled = ctx.GlobalBool("log")
@@ -568,7 +585,7 @@ func sidekickMain(ctx *cli.Context) {
 
 	var sites []*site
 	for i, siteStrs := range ctx.Args() {
-		site := configureSite(ctx, i+1, strings.Split(siteStrs, ","), healthCheckPath, healthCheckDuration)
+		site := configureSite(ctx, i+1, strings.Split(siteStrs, ","), healthCheckPath, healthCheckPort, healthCheckDuration)
 		sites = append(sites, site)
 	}
 	m := &multisite{sites}
@@ -605,6 +622,10 @@ func main() {
 		cli.StringFlag{
 			Name:  "health-path, p",
 			Usage: "health check path",
+		},
+		cli.IntFlag{
+			Name:  "health-port",
+			Usage: "health check port",
 		},
 		cli.IntFlag{
 			Name:  "health-duration, d",

--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,25 @@
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.package main
+
 package main
 
 import (
 	"testing"
 )
 
-func TestGetHealthCheckURL(t *testing.T) {
+func TestGetHealthCheckURL_Valid(t *testing.T) {
 	// ----- conditions -------------------------------------------------------
 	testCases := []struct {
 		name            string
@@ -26,16 +41,72 @@ func TestGetHealthCheckURL(t *testing.T) {
 			healthCheckPort: 4242,
 			want:            "http://minio1:4242/minio/health/ready",
 		},
+		{
+			name:            "PortSetToUpperLimit",
+			endpoint:        "http://minio1:9000",
+			healthCheckPath: "/minio/health/ready",
+			healthCheckPort: portUpperLimit,
+			want:            "http://minio1:65535/minio/health/ready",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// ----- call -----------------------------------------------------
-			healthCheckURL := getHealthCheckURL(tc.endpoint, tc.healthCheckPath, tc.healthCheckPort)
+			healthCheckURL, err := getHealthCheckURL(tc.endpoint, tc.healthCheckPath, tc.healthCheckPort)
 
 			// ----- verify ---------------------------------------------------
+			if err != nil {
+				t.Errorf("Expected no error, got %q", err)
+			}
+
 			if healthCheckURL != tc.want {
 				t.Errorf("Expected %q, got %q", tc.want, healthCheckURL)
+			}
+		})
+	}
+}
+
+func TestGetHealthCheckURL_Invalid(t *testing.T) {
+	// ----- conditions -------------------------------------------------------
+	want := ""
+
+	testCases := []struct {
+		name            string
+		endpoint        string
+		healthCheckPath string
+		healthCheckPort int
+	}{
+		{
+			name:     "BadEndpoint",
+			endpoint: "bad",
+		},
+		{
+			name:            "PortNumberBelowLowerLimit",
+			endpoint:        "http://minio1:9000",
+			healthCheckPath: "/minio/health/ready",
+			healthCheckPort: portLowerLimit - 1,
+		},
+		{
+			name:            "PortNumberAboveUpperLimit",
+			endpoint:        "http://minio1:9000",
+			healthCheckPath: "/minio/health/ready",
+			healthCheckPort: portUpperLimit + 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// ----- call -----------------------------------------------------
+			healthCheckURL, err := getHealthCheckURL(tc.endpoint, tc.healthCheckPath, tc.healthCheckPort)
+
+			// ----- verify ---------------------------------------------------
+			if err == nil {
+				t.Errorf("Expected an error")
+			}
+
+			if healthCheckURL != want {
+				t.Errorf("Expected %q, got %q", want, healthCheckURL)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGetHealthCheckURL(t *testing.T) {
+	// ----- conditions -------------------------------------------------------
+	testCases := []struct {
+		name            string
+		endpoint        string
+		healthCheckPath string
+		healthCheckPort int
+		want            string
+	}{
+		{
+			name:            "PortSetToZero",
+			endpoint:        "http://minio1:9000",
+			healthCheckPath: "/minio/health/ready",
+			want:            "http://minio1:9000/minio/health/ready",
+		},
+		{
+			name:            "PortSetToNonZeroValue",
+			endpoint:        "http://minio1:9000",
+			healthCheckPath: "/minio/health/ready",
+			healthCheckPort: 4242,
+			want:            "http://minio1:4242/minio/health/ready",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// ----- call -----------------------------------------------------
+			healthCheckURL := getHealthCheckURL(tc.endpoint, tc.healthCheckPath, tc.healthCheckPort)
+
+			// ----- verify ---------------------------------------------------
+			if healthCheckURL != tc.want {
+				t.Errorf("Expected %q, got %q", tc.want, healthCheckURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
related to #25 

I have tested locally with the following command:
```
./sidekick --health-path=/ --health-port=13133 --address :8000 http://localhost:8888
```