### PR TITLE
fix: each SITE is a comma separated list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,8 @@ $ sidekick --health-path=/minio/health/ready --address :8000 http://minio{1...4}
 
 ### Two sites with 4 servers each
 ```
-$ sidekick --health-path=/minio/health/ready http://site1-minio{1...4}:9000 http://site2-minio{1...4}:9000
+$ sidekick --health-path=/minio/health/ready http://site1-minio{1...4}:9000,http://site2-minio{1...4}:9000
 ```
-
-Note that the two sites are separated by space character. If all the servers in site-1 are down, then sidekick will failover to site-2.
 
 ## Realworld Example with spark-orchestrator
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ FLAGS:
   --version, -v                      print the version
 
 SITE:
-Each SITE is a comma separated list of zones of that site: http://172.17.0.{2...5},http://172.17.0.{6...9}
+Each SITE is a comma separated list of zones of the same site: http://172.17.0.{2...5},http://172.17.0.{6...9}
 If all servers in SITE1 are down, then the traffic is routed to the next site - SITE2.
+Two sites are separated by a space character.
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ sidekick --health-path=/minio/health/ready --address :8000 http://minio{1...4}
 
 ### Two sites with 4 servers each
 ```
-$ sidekick --health-path=/minio/health/ready http://site1-minio{1...4}:9000,http://site2-minio{1...4}:9000
+$ sidekick --health-path=/minio/health/ready http://site1-minio{1...4}:9000 http://site2-minio{1...4}:9000
 ```
 
 ## Realworld Example with spark-orchestrator


### PR DESCRIPTION
The examples section states that SITES should be separated by space which if false. It's comma - as stated in the usage section.