### PR TITLE
add settings to ensure higher system resources if possible

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -152,7 +152,7 @@ func parseCacheControlHeaders(header http.Header) *cacheControl {
 		}
 	}
 	cc, ok := header[CacheControl]
-	if !ok && c.expires.Equal(timeZero) {
+	if !ok && c.expires.IsZero() {
 		return nil
 	}
 	v := strings.Join(cc, "")
@@ -262,7 +262,7 @@ func (c *cacheControl) isStale(modTime time.Time) bool {
 		return true
 	}
 
-	if !c.expires.Equal(timeZero) && c.expires.Before(time.Now().Add(time.Duration(c.maxStale))) {
+	if !c.expires.IsZero() && c.expires.Before(time.Now().Add(time.Duration(c.maxStale))) {
 		return true
 	}
 
@@ -338,7 +338,7 @@ func (c cacheHeader) Expires() time.Time {
 			return t.UTC()
 		}
 	}
-	return timeZero
+	return time.Time{}
 }
 
 //ETag returns ETag from cached response
@@ -353,7 +353,7 @@ func (c cacheHeader) LastModified() time.Time {
 			return t.UTC()
 		}
 	}
-	return timeZero
+	return time.Time{}
 }
 
 const (

--- a/rlimit.go
+++ b/rlimit.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.package main
+
+package main
+
+import (
+	"runtime/debug"
+
+	"github.com/minio/minio/pkg/sys"
+)
+
+func setMaxResources() (err error) {
+	// Set the Go runtime max threads threshold to 90% of kernel setting.
+	sysMaxThreads, mErr := sys.GetMaxThreads()
+	if mErr == nil {
+		minioMaxThreads := (sysMaxThreads * 90) / 100
+		// Only set max threads if it is greater than the default one
+		if minioMaxThreads > 10000 {
+			debug.SetMaxThreads(minioMaxThreads)
+		}
+	}
+
+	var maxLimit uint64
+
+	// Set open files limit to maximum.
+	if _, maxLimit, err = sys.GetMaxOpenFileLimit(); err != nil {
+		return err
+	}
+
+	if err = sys.SetMaxOpenFileLimit(maxLimit, maxLimit); err != nil {
+		return err
+	}
+
+	// Set max memory limit as current memory limit.
+	if _, maxLimit, err = sys.GetMaxMemoryLimit(); err != nil {
+		return err
+	}
+
+	err = sys.SetMaxMemoryLimit(maxLimit, maxLimit)
+	return err
+}


### PR DESCRIPTION
also avoid racy usage of rand.New(), rand object is not
concurrency friendly with default NewSource() - to avoid this
seed the rand once and use global rand.Intn()