### PR TITLE
 Enable live pprof at /.pprof/

### DIFF
--- a/main.go
+++ b/main.go
@@ -819,7 +819,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "pprof",
-			Usage: "start and and listen on the specified address (e.g. `:6060`)",
+			Usage: "start and listen for profiling on the specified address (e.g. `:1337`)",
 		},
 	}
 	app.CustomAppHelpTemplate = `NAME:


### PR DESCRIPTION
Running `go tool pprof
http://localhost:8080/minio/pprof/profile?seconds=30` will get CPU
profiling for 20 seconds

Supported profilers are: goroutine, threadcreate, heap, allocs, block,
mutex, symbol, trace and profile (cpu profiling)
