### PR TITLE
Avoid setting a body recorder for healtcheck req/resp

### DIFF
--- a/main.go
+++ b/main.go
@@ -280,7 +280,7 @@ func (b *Backend) healthCheck() {
 		}
 		if globalTrace != "application" {
 			if resp != nil {
-				httpInternalTrace(req, resp, reqTime, respTime, b)
+				traceHealthCheckReq(req, resp, reqTime, respTime, b)
 			}
 		}
 		time.Sleep(b.healthCheckDuration)


### PR DESCRIPTION
Currently, the code sends a healthcheck request, then setup a recorder
 for the request and response body, which does not work obviously.

This also seems to be causing a leak inside golang http code. Removing the
unnecessary code fixes the leak.