### PR TITLE
feat: support auto tls

### DIFF
--- a/main.go
+++ b/main.go
@@ -1116,7 +1116,7 @@ func sidekickMain(ctx *cli.Context) {
 		}
 		fingerprint := sha256.Sum256(certificates.Certificate[0])
 		console.Printf("\nCertificate: % X\n", fingerprint[:len(fingerprint)/2])
-		console.Printf("             % X", fingerprint[len(fingerprint)/2:])
+		console.Printf("			 % X", fingerprint[len(fingerprint)/2:])
 		var publicKeyDER []byte
 		switch privateKey := certificates.PrivateKey.(type) {
 		case *ecdsa.PrivateKey:
@@ -1129,6 +1129,7 @@ func sidekickMain(ctx *cli.Context) {
 		}
 		publicKey := sha256.Sum256(publicKeyDER)
 		console.Println("\nPublic Key:  " + base64.StdEncoding.EncodeToString(publicKey[:]))
+		console.Println()
 		globalTLSCert.Store(&cert)
 
 		tlsConfig := &tls.Config{

--- a/main.go
+++ b/main.go
@@ -1113,8 +1113,8 @@ func sidekickMain(ctx *cli.Context) {
 			console.Fatalln(err)
 		}
 		fingerprint := sha256.Sum256(certificates.Certificate[0])
-		console.Printf("\nCertificate: % X\n", fingerprint[:len(fingerprint)/2])
-		console.Printf("			 % X", fingerprint[len(fingerprint)/2:])
+		console.Printf("\nCertificate: % X", fingerprint[:len(fingerprint)/2])
+		console.Printf("\n             % X", fingerprint[len(fingerprint)/2:])
 		var publicKeyDER []byte
 		switch privateKey := certificates.PrivateKey.(type) {
 		case *ecdsa.PrivateKey:

--- a/main.go
+++ b/main.go
@@ -525,7 +525,7 @@ func (m *multisite) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		cert := globalTLSCert.Load()
 		if cert != nil {
 			w.WriteHeader(200)
-			w.Write(*globalTLSCert.Load())
+			w.Write(*cert)
 		} else {
 			w.WriteHeader(200)
 			w.Write([]byte("No certificates found"))

--- a/main.go
+++ b/main.go
@@ -1093,7 +1093,6 @@ func sidekickMain(ctx *cli.Context) {
 		}
 		console.Printf("Generated TLS certificate for host '%s'\n", ctx.String("auto-tls-host"))
 		console.Printf("certFile:\n%s\n", string(cert))
-		console.Printf("keyFile:\n%s\n", string(key))
 		certificates, err := tls.X509KeyPair(cert, key)
 		if err != nil {
 			console.Fatalln(err)

--- a/main.go
+++ b/main.go
@@ -521,14 +521,12 @@ func (m *multisite) populate() {
 }
 
 func (m *multisite) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == certificatesPath {
+	if r.Method == http.MethodGet && r.URL.Path == certificatesPath {
 		cert := globalTLSCert.Load()
 		if cert != nil {
-			w.WriteHeader(200)
 			w.Write(*cert)
 		} else {
-			w.WriteHeader(200)
-			w.Write([]byte("No certificates found"))
+			http.Error(w, "no configured certificates found", http.StatusNotFound)
 		}
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -17,8 +17,11 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -60,8 +63,9 @@ import (
 var version = "0.0.0-dev"
 
 const (
-	slashSeparator = "/"
-	healthPath     = "/v1/health"
+	slashSeparator   = "/"
+	healthPath       = "/v1/health"
+	certificatesPath = "/v1/certificates"
 )
 
 var (
@@ -76,6 +80,7 @@ var (
 	globalConnStats      atomic.Pointer[[]*ConnStats]
 	log2                 *logrus.Logger
 	globalHostBalance    string
+	globalTLSCert        atomic.Pointer[[]byte]
 )
 
 const (
@@ -516,15 +521,28 @@ func (m *multisite) populate() {
 }
 
 func (m *multisite) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == certificatesPath {
+		cert := globalTLSCert.Load()
+		if cert != nil {
+			w.WriteHeader(200)
+			w.Write(*globalTLSCert.Load())
+		} else {
+			w.WriteHeader(200)
+			w.Write([]byte("No certificates found"))
+		}
+		return
+	}
 	w.Header().Set("Server", "SideKick") // indicate sidekick is serving
 	for _, s := range *m.sites.Load() {
 		if s.Online() {
-			if r.URL.Path == healthPath {
+			switch r.URL.Path {
+			case healthPath:
 				// Health check endpoint should return success
 				return
+			default:
+				s.ServeHTTP(w, r)
+				return
 			}
-			s.ServeHTTP(w, r)
-			return
 		}
 	}
 	writeErrorResponse(w, r, errors.New("all backend servers are offline"))
@@ -1092,11 +1110,27 @@ func sidekickMain(ctx *cli.Context) {
 			console.Fatalln(err)
 		}
 		console.Printf("Generated TLS certificate for host '%s'\n", ctx.String("auto-tls-host"))
-		console.Printf("certFile:\n%s\n", string(cert))
 		certificates, err := tls.X509KeyPair(cert, key)
 		if err != nil {
 			console.Fatalln(err)
 		}
+		fingerprint := sha256.Sum256(certificates.Certificate[0])
+		console.Printf("\nCertificate: % X\n", fingerprint[:len(fingerprint)/2])
+		console.Printf("             % X", fingerprint[len(fingerprint)/2:])
+		var publicKeyDER []byte
+		switch privateKey := certificates.PrivateKey.(type) {
+		case *ecdsa.PrivateKey:
+			publicKeyDER, err = x509.MarshalPKIXPublicKey(privateKey.Public())
+		default:
+			console.Fatalln(fmt.Errorf("unsupported private key type %T", privateKey))
+		}
+		if err != nil {
+			console.Fatalln(err)
+		}
+		publicKey := sha256.Sum256(publicKeyDER)
+		console.Println("\nPublic Key:  " + base64.StdEncoding.EncodeToString(publicKey[:]))
+		globalTLSCert.Store(&cert)
+
 		tlsConfig := &tls.Config{
 			PreferServerCipherSuites: true,
 			NextProtos:               []string{"http/1.1", "h2"},

--- a/tls.go
+++ b/tls.go
@@ -72,6 +72,9 @@ func generateTLSCertKey(host string) ([]byte, []byte, error) {
 	var priv interface{}
 	var err error
 	priv, err = ecdsa.GenerateKey(elliptic.P256(), crand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
 	notBefore := time.Now()
 	notAfter := notBefore.Add(validFor)
 

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2021-2024 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	crand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+// generateTLSCertKey creates valid key/cert with registered DNS or IP address
+// depending on the passed parameter. That way, we can use tls config without
+// passing InsecureSkipVerify flag.  This code is a simplified version of
+// https://golang.org/src/crypto/tls/generate_cert.go
+func generateTLSCertKey(host string) ([]byte, []byte, error) {
+	validFor := 365 * 24 * time.Hour
+	rsaBits := 2048
+
+	if len(host) == 0 {
+		return nil, nil, fmt.Errorf("Missing host parameter")
+	}
+
+	publicKey := func(priv interface{}) interface{} {
+		switch k := priv.(type) {
+		case *rsa.PrivateKey:
+			return &k.PublicKey
+		case *ecdsa.PrivateKey:
+			return &k.PublicKey
+		default:
+			return nil
+		}
+	}
+
+	pemBlockForKey := func(priv interface{}) *pem.Block {
+		switch k := priv.(type) {
+		case *rsa.PrivateKey:
+			return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
+		case *ecdsa.PrivateKey:
+			b, err := x509.MarshalECPrivateKey(k)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to marshal ECDSA private key: %v", err)
+				os.Exit(2)
+			}
+			return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+		default:
+			return nil
+		}
+	}
+
+	var priv interface{}
+	var err error
+	priv, err = rsa.GenerateKey(crand.Reader, rsaBits)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(validFor)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := crand.Int(crand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	hosts := strings.Split(host, ",")
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	template.IsCA = true
+	template.KeyUsage |= x509.KeyUsageCertSign
+
+	derBytes, err := x509.CreateCertificate(crand.Reader, &template, &template, publicKey(priv), priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create certificate: %w", err)
+	}
+
+	certOut := bytes.NewBuffer([]byte{})
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	keyOut := bytes.NewBuffer([]byte{})
+	pem.Encode(keyOut, pemBlockForKey(priv))
+
+	return certOut.Bytes(), keyOut.Bytes(), nil
+}

--- a/tls.go
+++ b/tls.go
@@ -18,6 +18,7 @@ package main
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"crypto/elliptic"
 	crand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -37,8 +38,6 @@ import (
 // https://golang.org/src/crypto/tls/generate_cert.go
 func generateTLSCertKey(host string) ([]byte, []byte, error) {
 	validFor := 365 * 24 * time.Hour
-	rsaBits := 2048
-
 	if len(host) == 0 {
 		return nil, nil, fmt.Errorf("Missing host parameter")
 	}
@@ -72,11 +71,7 @@ func generateTLSCertKey(host string) ([]byte, []byte, error) {
 
 	var priv interface{}
 	var err error
-	priv, err = rsa.GenerateKey(crand.Reader, rsaBits)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
-	}
-
+	priv, err = ecdsa.GenerateKey(elliptic.P256(), crand.Reader)
 	notBefore := time.Now()
 	notAfter := notBefore.Add(validFor)
 


### PR DESCRIPTION
feat: support auto tls
```log
Generated TLS certificate for host 'localhost'

Certificate: E8 96 7B 11 F0 46 91 16 1F AB B1 1E 8E B3 A8 72
             3B 7E 5F 4D F0 F6 37 30 45 C2 EE 95 AD 90 A1 1D
Public Key:  G5UKIKear644oohL5G2Un47tnnVXf3IK625YieKrC/8=

   LOG: 03:06:25.805 [200 OK]  http://127.0.0.1:9000 GET /minio/health/cluster                   1.406ms      ↑ 0 B ↓ 0 B
```