### PR TITLE
Add optimistic mode

### DIFF
--- a/http-tracer.go
+++ b/http-tracer.go
@@ -248,20 +248,6 @@ func Trace(f http.HandlerFunc, logBody bool, w http.ResponseWriter, r *http.Requ
 	rw.LogBody = logBody
 	f(rw, r)
 
-	if backend.healthOptimistic {
-		// when running in optimistic mode the node will be taken out
-		// of the pool when it returns one of the following HTTP
-		// response status:
-		// - 502 Bad gateway (i.e. can't connect to remote)
-		// - 503 Service unavailable
-		// - 504 Gateway timeout
-		if rw.StatusCode == http.StatusBadGateway || rw.StatusCode == http.StatusServiceUnavailable || rw.StatusCode == http.StatusGatewayTimeout {
-			if backend.setOffline() {
-				go backend.healthCheck()
-			}
-		}
-	}
-
 	rq := traceRequestInfo{
 		Time:     time.Now().UTC(),
 		Method:   r.Method,

--- a/http-tracer.go
+++ b/http-tracer.go
@@ -248,7 +248,7 @@ func Trace(f http.HandlerFunc, logBody bool, w http.ResponseWriter, r *http.Requ
 	rw.LogBody = logBody
 	f(rw, r)
 
-	if backend.optimistic {
+	if backend.healthOptimistic {
 		// when running in optimistic mode the node will be taken out
 		// of the pool when it returns one of the following HTTP
 		// response status:


### PR DESCRIPTION
This PR adds the `--optimistic` flag that reduces the amount of health-checks significantly. It works like this:
1. Only an initial health-check is done when starting sidekick to determine which nodes are active.
2. When a node reports to be healthy, then the health-check for that node is stopped.
3. When a node reports either 502 (bad gateway), 503 (service unavailable) or 504 (gateway timeout) then the node is taken out of the pool immediately and it will start health-checks again.
4. When the node is healthy again, it's added back to the pool and health checks are stopped.

There are two advantages to this approach:
- Less health checks needed that can become expensive in a cluster with a lot of nodes.
- Node is taken out of the pool (for that sidekick node) immediately after reporting failure.

The major disadvantages are:
- It only takes out the node upon 502, 503 and 504. Note that an unreachable node also reports 502 by the reverse-proxy logic.
- It relies on clients doing retries when a request was forwarded to a bad node. Clients should already do this anyway.

I would like to hear your comments...