### PR TITLE
Add signal exit-code option

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ var (
 	globalHostBalance    string
 	globalTLSCert        atomic.Pointer[[]byte]
 	globalKeyPassword    string
+	globalExitCode       int
 )
 
 const (
@@ -1075,6 +1076,7 @@ func sidekickMain(ctx *cli.Context) {
 		globalHostBalance = "least"
 	}
 	globalKeyPassword = ctx.GlobalString("key-password")
+	globalExitCode = ctx.GlobalInt("exit-code")
 
 	tlsMaxVersion := uint16(tls.VersionTLS13)
 	switch tlsMax := ctx.GlobalString("tls-max"); tlsMax {
@@ -1242,7 +1244,7 @@ func sidekickMain(ctx *cli.Context) {
 			})
 		default:
 			console.Infof("caught signal '%s'\n", signal)
-			os.Exit(1)
+			os.Exit(globalExitCode)
 		}
 	}
 }
@@ -1380,6 +1382,11 @@ func main() {
 			Usage:  "specify maximum supported TLS version",
 			Value:  "1.3",
 			Hidden: true,
+		},
+		cli.IntFlag{
+			Name:  "exit-code",
+			Usage: "exit code to use when program terminates by a signal",
+			Value: 1,
 		},
 	}
 	app.CustomAppHelpTemplate = `NAME:


### PR DESCRIPTION
The change maintains backwards compatibility since the default value is still 1.

Fix https://github.com/minio/sidekick/issues/130

### New Feature: Configurable Exit Code

* **Global variable added**: Introduced `globalExitCode` as an integer to store the configurable exit code. (`main.go`, [main.goR86](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R86))
* **CLI flag added**: Added a new `--exit-code` flag to allow users to specify the exit code when the program terminates. The default value is set to `1`. (`main.go`, [main.goR1386-R1390](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R1386-R1390))
* **Signal handling updated**: Modified the signal handling logic to use `globalExitCode` for program termination instead of a hardcoded value. (`main.go`, [main.goL1245-R1247](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L1245-R1247))
* **Flag initialization**: Set `globalExitCode` to the value provided by the `--exit-code` flag during program initialization. (`main.go`, [main.goR1079](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R1079))